### PR TITLE
Disable default page in Module Configure

### DIFF
--- a/Website/src/activitys/ConfigureActivity.tsx
+++ b/Website/src/activitys/ConfigureActivity.tsx
@@ -1,5 +1,3 @@
-import { Page } from "@Components/onsenui/Page";
-import { Toolbar } from "@Components/onsenui/Toolbar";
 import { useActivity } from "@Hooks/useActivity";
 import React from "react";
 import { SuFile } from "@Native/SuFile";
@@ -31,21 +29,8 @@ const ConfigureActivity = () => {
     }
   }, []);
 
-  const renderToolbar = () => {
-    return (
-      <Toolbar modifier="noshadow">
-        <Toolbar.Left>
-          <Toolbar.BackButton onClick={context.popPage} />
-        </Toolbar.Left>
-        <Toolbar.Center>Configure {extra.modulename}</Toolbar.Center>
-      </Toolbar>
-    );
-  };
-
   return (
-    <Page renderToolbar={renderToolbar}>
-      <PreviewErrorBoundary modid={extra.moduleid} children={config} renderElement={ConfigureView} />
-    </Page>
+    <PreviewErrorBoundary modid={extra.moduleid} children={config} renderElement={ConfigureView} />
   );
 };
 


### PR DESCRIPTION
The pull diableds the default page creation in Module Configure.

User now have to build theirself a page

Example:
```jsx
import React from "react";
import { Page, Toolbar } from "@mmrl/ui"
import { Typography } from "@mui/material"

function Config() {
  const renderToolbar = () => {
    return (
      <Toolbar>
        <Toolbar.Center>
          Config
        </Toolbar.Center>
      </Toolbar>
    )
  }

  return (
    <Page
      renderToolbar={renderToolbar}
      modifier="noshadow"
    >
      <Typography variant="h2" gutterBottom>
        h2. Heading
      </Typography>
    </Page>
  );
}

export default Config
```